### PR TITLE
Korrekte Reihenfolge der Ausgabe des Archivtitels

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -3,7 +3,7 @@
 		<?php if ( have_posts() ) { ?>
 			<header class="archive-header">
 				<h1>
-					<?php esc_html( the_archive_title() ); ?>
+					<?php echo esc_html( get_the_archive_title() ); ?>
 				</h1>
 				<?php the_archive_description(); ?>
 			</header>


### PR DESCRIPTION
Da die Funktion "the_archive_title" den Archivtitel sofort ausgibt (sprich an den Browser sendet), findet der Aufruf der Funktion "esc_html" zu spät statt (weil bereits geoutputed). Die von mir modifizierte Reihenfolge sorgt dafür, dass der Archivtitel eingelesen, gesäubert und dann ausgegeben wird. Ungetestet, da aus dem Urlaub ;)

Muss man den Titel an dieser Stelle HTML cleanen? Twenty Fifteen macht es nicht. Es gab mal einen globalen Filter, der dafür sorgte, dass Titel jeglicher Art immer gesäubert ausgegeben werden ;)
